### PR TITLE
change the roster service and duty roster controller

### DIFF
--- a/e-ward-frontend/src/components/SwapRequestItem.js
+++ b/e-ward-frontend/src/components/SwapRequestItem.js
@@ -30,7 +30,11 @@ const SwapRequestItem = ({ request, refresh, activeTab, currentUserId }) => {
     }
   };
 
-  const preferredSlots = request.requestMeta?.preferredSlots || [];
+  //const preferredSlots = request.requestMeta?.preferredSlots || [];
+
+ const preferredSlots = request.requestMeta?.preferredSlots 
+  || request.preferredSlots  // sometimes nested differently
+  || [];
 
   // Hide action buttons if viewing own sent requests
   const showActions =

--- a/e-ward-frontend/src/pages/DutyRosterPage.js
+++ b/e-ward-frontend/src/pages/DutyRosterPage.js
@@ -74,24 +74,54 @@ export default function DutyRosterPage() {
     }
   };
 
-  const handleTargetStaffChange = async (selectedOption) => {
-    setSwapData({ ...swapData, toStaff: selectedOption, requestedDate: "", requestedShift: "" });
-    setAvailableTargetSlots([]);
-    if (selectedOption) {
-      try {
-        const res = await swapService.getStaffSlots(month, year, selectedOption.value);
-        const slots = res.data || res;
-        if (Array.isArray(slots)) {
-          setAvailableTargetSlots(slots);
-        } else {
-          setAvailableTargetSlots([]);
-        }
-      } catch (err) {
-        setAvailableTargetSlots([]);
-        toast.error("Could not fetch target staff's duties.");
+  // const handleTargetStaffChange = async (selectedOption) => {
+  //   setSwapData({ ...swapData, toStaff: selectedOption, requestedDate: "", requestedShift: "" });
+  //   setAvailableTargetSlots([]);
+  //   if (selectedOption) {
+  //     try {
+  //       const res = await swapService.getStaffSlots(month, year, selectedOption.value);
+  //       const slots = res.data || res;
+  //       if (Array.isArray(slots)) {
+  //         setAvailableTargetSlots(slots);
+  //       } else {
+  //         setAvailableTargetSlots([]);
+  //       }
+  //     } catch (err) {
+  //       setAvailableTargetSlots([]);
+  //       toast.error("Could not fetch target staff's duties.");
+  //     }
+  //   }
+  // };
+
+//   
+
+const handleTargetStaffChange = async (selectedOption) => {
+  setSwapData({ ...swapData, toStaff: selectedOption, requestedDate: "", requestedShift: "" });
+  setAvailableTargetSlots([]);
+
+  if (selectedOption) {
+    try {
+      // ✅ Find roster that actually contains swapData.date
+      const matchingRoster = rosters.find(
+        (r) => r.data && Object.keys(r.data).includes(swapData.date)
+      );
+
+      console.log("matchingRoster:", matchingRoster); // should now find it
+
+      if (!matchingRoster) {
+        toast.error("No roster found containing your shift date.");
+        return;
       }
+
+      const res = await swapService.getStaffSlots(matchingRoster.id, year, selectedOption.value);
+      const slots = res.data || res;
+      setAvailableTargetSlots(Array.isArray(slots) ? slots : []);
+    } catch (err) {
+      setAvailableTargetSlots([]);
+      toast.error("Could not fetch target staff's duties.");
     }
-  };
+  }
+};
 
   function handleAssignmentChange(index, field, value) {
     const copy = [...assignments];

--- a/e-ward-frontend/src/pages/SwapRequestPage.js
+++ b/e-ward-frontend/src/pages/SwapRequestPage.js
@@ -56,14 +56,14 @@ const SwapRequestPage = () => {
 const receivedRequests = requests.filter(r =>
   r.requestType === "DIRECT" &&
   r.peerApprovalStatus === "PENDING" &&
-  r.targetName === currentUserName  // match by name
+  String(r.targetStaffId) === String(currentUserId)
+  //r.targetName === currentUserName  // match by name
 );
 
 // 4. MY SENT: Anything you started
 const submittedRequests = requests.filter(r =>
-  r.requesterName === currentUserName  // match by name
+  String(r.requesterStaffId) === String(currentUserId) 
 );
-
 
 
   // 5. HISTORY: Finished items

--- a/e-ward-frontend/src/services/swapService.js
+++ b/e-ward-frontend/src/services/swapService.js
@@ -56,9 +56,14 @@ function adminReject(id, approverUserId) {
 }
 
 // FETCH TARGET STAFF DUTIES
-function getStaffSlots(month, year, staffId) {
+/*function getStaffSlots(month, year, staffId) {
   return api.get(`/rosters/${month}/${year}/staff/${staffId}/slots`);
+}*/
+
+function getStaffSlots(rosterId, year, staffId) {
+  return api.get(`/rosters/${rosterId}/${year}/staff/${staffId}/slots`);
 }
+
 // ──────────────────────────────────────────────
 // EXPORT
 // ──────────────────────────────────────────────

--- a/src/main/java/com/example/E_WardApplication/controller/DutyRosterController.java
+++ b/src/main/java/com/example/E_WardApplication/controller/DutyRosterController.java
@@ -107,15 +107,27 @@ public class DutyRosterController {
     }
 
     // NEW - GRAB THE STAFFSHIFT
-    @GetMapping("/{month}/{year}/staff/{staffId}/slots")
+//    @GetMapping("/{month}/{year}/staff/{staffId}/slots")
+//    @PreAuthorize("hasAnyRole('ADMIN','STAFF')")
+//    public ResponseEntity<List<Map<String,String>>> getStaffSlotsForMonth(
+//            @PathVariable int month,
+//            @PathVariable int year,
+//            @PathVariable Long staffId) {
+//
+//        // iterate rosters and build a list of { date, shift } where staffId is assigned
+//        List<Map<String, String>> slots = service.findSlotsForStaffInMonth(staffId, month, year);
+//        return ResponseEntity.ok(slots);
+//    }
+
+    // ✅ Change {month} to {rosterId}
+    @GetMapping("/{rosterId}/{year}/staff/{staffId}/slots")
     @PreAuthorize("hasAnyRole('ADMIN','STAFF')")
     public ResponseEntity<List<Map<String,String>>> getStaffSlotsForMonth(
-            @PathVariable int month,
+            @PathVariable Long rosterId,
             @PathVariable int year,
             @PathVariable Long staffId) {
 
-        // iterate rosters and build a list of { date, shift } where staffId is assigned
-        List<Map<String, String>> slots = service.findSlotsForStaffInMonth(staffId, month, year);
+        List<Map<String, String>> slots = service.findSlotsForStaffInRoster(staffId, rosterId);
         return ResponseEntity.ok(slots);
     }
 

--- a/src/main/java/com/example/E_WardApplication/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/E_WardApplication/exception/GlobalExceptionHandler.java
@@ -69,4 +69,5 @@ public class GlobalExceptionHandler {
         body.put("path", ""); // optional - could be set from request if injected
         return new ResponseEntity<>(body, new HttpHeaders(), status);
     }
+
 }

--- a/src/main/java/com/example/E_WardApplication/security/JwtTokenProvider.java
+++ b/src/main/java/com/example/E_WardApplication/security/JwtTokenProvider.java
@@ -64,4 +64,6 @@ public class JwtTokenProvider {
         }
         return false;
     }
+
+
 }

--- a/src/main/java/com/example/E_WardApplication/service/DutyRosterService.java
+++ b/src/main/java/com/example/E_WardApplication/service/DutyRosterService.java
@@ -15,6 +15,7 @@ public interface DutyRosterService {
     void delete(Long id);
     boolean staffHasSlot(Long staffId, LocalDate date, String shift);
     List<Map<String, String>> findSlotsForStaffInMonth(Long staffId, int month, int year);
+    List<Map<String, String>> findSlotsForStaffInRoster(Long staffId, Long rosterId);
 
 
 }

--- a/src/main/java/com/example/E_WardApplication/service/impl/DutyRosterServiceImpl.java
+++ b/src/main/java/com/example/E_WardApplication/service/impl/DutyRosterServiceImpl.java
@@ -143,6 +143,37 @@ public class DutyRosterServiceImpl implements DutyRosterService {
         return result;
     }
 
+    //FILTER SLOTS BY ROSTER ID
+    @Override
+    public List<Map<String, String>> findSlotsForStaffInRoster(Long staffId, Long rosterId) {
+        List<Map<String, String>> result = new ArrayList<>();
+
+        DutyRoster roster = repository.findById(rosterId)
+                .orElseThrow(() -> new RuntimeException("Roster not found"));
+
+        Map<String, Object> data = roster.getData();
+        if (data == null) return result;
+
+        for (String dateKey : data.keySet()) {
+            Map<String, Object> shifts = (Map<String, Object>) data.get(dateKey);
+            if (shifts == null) continue;
+            for (String shiftName : Arrays.asList("morning", "evening", "night")) {
+                List<Map<String, Object>> list = (List<Map<String, Object>>) shifts.getOrDefault(shiftName, new ArrayList<>());
+                for (Map<String, Object> entry : list) {
+                    Object idObj = entry.get("id");
+                    long idVal = idObj instanceof Integer ? ((Integer) idObj).longValue() : (Long) idObj;
+                    if (Objects.equals(idVal, staffId)) {
+                        Map<String, String> m = new HashMap<>();
+                        m.put("date", dateKey);
+                        m.put("shift", shiftName);
+                        result.add(m);
+                    }
+                }
+            }
+        }
+        return result;
+    }
+
 
     private DutyRosterDTO toDto(DutyRoster d) {
         DutyRosterDTO dto = new DutyRosterDTO();


### PR DESCRIPTION
The DutyRosterController slot endpoint was originally designed to accept month as a path variable, but the frontend was sending rosterId instead. So we updated the controller to accept rosterId, and added a new service method findSlotsForStaffInRoster to the service interface and its implementation, which fetches slots by looking up the roster directly by ID rather than searching by month